### PR TITLE
Support URL parameters for open

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include theos/makefiles/common.mk
 
 TOOL_NAME = open
 open_FILES = open.m
-open_PRIVATE_FRAMEWORKS = SpringBoardServices
+open_PRIVATE_FRAMEWORKS = SpringBoardServices MobileCoreServices
 open_CODESIGN_FLAGS = -SEntitlements.plist
 open_FRAMEWORKS 	= UIKit
 

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,6 @@ TOOL_NAME = open
 open_FILES = open.m
 open_PRIVATE_FRAMEWORKS = SpringBoardServices
 open_CODESIGN_FLAGS = -SEntitlements.plist
+open_FRAMEWORKS 	= UIKit
 
 include $(THEOS_MAKE_PATH)/tool.mk

--- a/control
+++ b/control
@@ -1,5 +1,5 @@
 Package: com.conradkramer.open
-Version: 1.1.1
+Version: 1.1.2
 Architecture: iphoneos-arm
 Maintainer: BigBoss <bigboss@thebigboss.org>
 Author: Conrad Kramer <support@kramerapps.com>

--- a/open.m
+++ b/open.m
@@ -1,6 +1,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <stdio.h>
 #include <UIKit/UIKit.h>
+#include <MobileCoreServices/LSApplicationWorkspace.h>
 
 #ifndef SPRINGBOARDSERVICES_H_
 extern int SBSLaunchApplicationWithIdentifier(CFStringRef identifier, Boolean suspended);
@@ -24,11 +25,11 @@ int main(int argc, char **argv, char **envp)
     if (ret != 0) {
         fprintf(stderr, "Couldn't open application: %s. Reason: %i, ", argv[1], ret);
         CFShow(SBSApplicationLaunchingErrorString(ret));
-    }
 
-    NSURL *url = [NSURL URLWithString:(NSString*)identifier];
-    if (![[UIApplication sharedApplication] openURL:url]) {
-        fprintf(stderr, "openURL %s also failed.\n", [[url absoluteString] UTF8String]);
+        NSURL *url = [NSURL URLWithString:(NSString*)identifier];
+        if (![[LSApplicationWorkspace defaultWorkspace] openURL:url]) {
+            fprintf(stderr, "openURL %s also failed.\n", [[url absoluteString] UTF8String]);
+        }
     }
 
     CFRelease(identifier);

--- a/open.m
+++ b/open.m
@@ -1,5 +1,6 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <stdio.h>
+#include <UIKit/UIKit.h>
 
 #ifndef SPRINGBOARDSERVICES_H_
 extern int SBSLaunchApplicationWithIdentifier(CFStringRef identifier, Boolean suspended);
@@ -23,6 +24,11 @@ int main(int argc, char **argv, char **envp)
     if (ret != 0) {
         fprintf(stderr, "Couldn't open application: %s. Reason: %i, ", argv[1], ret);
         CFShow(SBSApplicationLaunchingErrorString(ret));
+    }
+
+    NSURL *url = [NSURL URLWithString:(NSString*)identifier];
+    if (![[UIApplication sharedApplication] openURL:url]) {
+        fprintf(stderr, "openURL %s also failed.\n", [[url absoluteString] UTF8String]);
     }
 
     CFRelease(identifier);

--- a/open.m
+++ b/open.m
@@ -1,6 +1,5 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <stdio.h>
-#include <UIKit/UIKit.h>
 #include <MobileCoreServices/LSApplicationWorkspace.h>
 
 #ifndef SPRINGBOARDSERVICES_H_

--- a/open.m
+++ b/open.m
@@ -29,6 +29,8 @@ int main(int argc, char **argv, char **envp)
         NSURL *url = [NSURL URLWithString:(NSString*)identifier];
         if (![[LSApplicationWorkspace defaultWorkspace] openURL:url]) {
             fprintf(stderr, "openURL %s also failed.\n", [[url absoluteString] UTF8String]);
+        } else {
+            ret = 0;
         }
     }
 


### PR DESCRIPTION
Great for opening a web page via command line with the default browser, when you need to test an app's [URL scheme support](https://developer.apple.com/library/ios/featuredarticles/iPhoneURLScheme_Reference/Introduction/Introduction.html#//apple_ref/doc/uid/TP40007899), or to check if an app on the system can handle the URL parameter.

I thought it would be good to just integrate this feature with Open instead of creating a separate tweak OpenURL.
